### PR TITLE
README: `uv install` -> `uv add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv install pytest pytest-asyncio aiofiles
+uv add pytest pytest-asyncio aiofiles
 
 # Install the package in development mode
 pip install -e .


### PR DESCRIPTION
or maybe it was supposed to be `uv pip install`.

Shouldn't the deps be in the pyproject.toml file?